### PR TITLE
setup for the production build

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,12 @@ Testing process with mocha, chai and jsdom, and for CI, I`m using TravisCI
 
 Using whatwg-fetch for fetching data with http, and json-server and json-schema-faker for mocking the API
 
+### Production Build 
 
-
-
-
-
+Using a webpack config for the production using the following plugins :
+    - CommonsChunkPlugin for spliting bundles.
+    - WebpackMd5Hash for cache bursting.
+    - ExtractTextPlugin for creating a css bundle separately.
+    - HtmlWebpackPlugin for minify the html index and injecting bundles.
+    - DedupePlugin for eliminate duplicate packages when generating bundle.
+    - UglifyJsPlugin for minify JS.

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 /**
  * Created by raphael on 19/04/17.
  */
+import './index.css';
 import {getUsers, deleteUser} from './api/userApi'
 
 getUsers().then(result => {

--- a/tools/webpack.config.prod.js
+++ b/tools/webpack.config.prod.js
@@ -5,6 +5,8 @@
 import path from 'path';
 import webpack from 'webpack';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
+import WebpackMd5Hash from 'webpack-md5-hash';
+import ExtractTextPlugin from 'extract-text-webpack-plugin';
 
 export default {
   debug: true,
@@ -18,13 +20,21 @@ export default {
   output: {
     path: path.resolve(__dirname, '../dist'),
     publicPath: '/',
-    filename: 'bundle.js'
+    filename: '[name]-[chunkhash].js'
   },
   plugins: [
-    //bundles vendors, at entry vendor
-    new webpack.optimize.CommonsChunkPlugin(
-      /* chunkName= */"vendor", /* filename= */"vendor.bundle.js"
-    ),
+    // Generate an external css file with a hash in the filename.
+    new ExtractTextPlugin('[name].[contenthash].css'),
+
+    // Hash the files using MD5 so that their names change when the content changes.
+    new WebpackMd5Hash(),
+
+    // Use CommonsChunkPlugin to create a separate bundle
+    // of vendor libraries so that they're cached separately.
+    new webpack.optimize.CommonsChunkPlugin({
+        name: 'vendor' ///* chunkName= */"vendor", /* filename= */"vendor.bundle-[hash].js"
+    }),
+
     // Create HTML file that includes reference to bundled JS.
     new HtmlWebpackPlugin({
       template: 'src/index.html',
@@ -42,15 +52,17 @@ export default {
         minifyURLs: true
       }
     }),
+
     // Eliminate duplicate packages when generating bundle.
     new webpack.optimize.DedupePlugin(),
+
     // Minify JS.
     new webpack.optimize.UglifyJsPlugin()
   ],
   module: {
     loaders: [
       { test: /\.js$/, exclude: /node_modules/, loaders: ['babel'] },
-      { test: /\.css$/, loaders: ['style', 'css'] }
+      { test: /\.css$/, loaders: ExtractTextPlugin.extract('css?sourceMap') }
     ]
   }
 }

--- a/tools/webpack.config.prod.js
+++ b/tools/webpack.config.prod.js
@@ -62,7 +62,7 @@ export default {
   module: {
     loaders: [
       { test: /\.js$/, exclude: /node_modules/, loaders: ['babel'] },
-      { test: /\.css$/, loaders: ExtractTextPlugin.extract('css?sourceMap') }
+      { test: /\.css$/, loader: ExtractTextPlugin.extract('css?sourceMap') }
     ]
   }
 }


### PR DESCRIPTION
Using a webpack config for the production using the following plugins :
    - CommonsChunkPlugin for spliting bundles.
    - WebpackMd5Hash for cache bursting.
    - ExtractTextPlugin for creating a css bundle separately.
    - HtmlWebpackPlugin for minify the html index and injecting bundles.
    - DedupePlugin for eliminate duplicate packages when generating bundle.
    - UglifyJsPlugin for minify JS.